### PR TITLE
Fix angular orderBy notarray error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "angular-loading-bar": "^0.8.0",
     "angular-resource": "^1.4.8",
     "angular-sanitize": "^1.4.8",
+    "angular-toarrayfilter": "^1.0.1",
     "angular-ui-bootstrap": "^0.14.3",
     "angular-ui-router": "^0.2.15",
     "bootstrap": "^3.3.6",

--- a/public/partials/attributeOverview.html
+++ b/public/partials/attributeOverview.html
@@ -2,9 +2,9 @@
   <h3>{{attribute}}</h3>
   <div class="col-md-12">
     <table class="table table-bordered">
-      <tr ng-repeat="(key, value) in fields | orderBy:'toString()'">
-        <th>{{key}}</th>
-        <td>{{value}}</td>
+      <tr ng-repeat="field in fields | toArray | orderBy:'$key'">
+        <th>{{field.$key}}</th>
+        <td>{{field.$value}}</td>
       </tr>
     </table>
   </div>

--- a/src/main.js
+++ b/src/main.js
@@ -7,13 +7,15 @@ var selectSchemaResolvers = require('./resolvers/SelectSchemaResolvers')
 window.jQuery = require('jquery')
 require('bootstrap')
 require('angular-breadcrumb');
-require('angular-drag-and-drop-lists')
+require('angular-drag-and-drop-lists');
+require('angular-toarrayfilter');
 
 angular.module(
   'capi-ui',
   [
     'ncy-angular-breadcrumb',
     'dndLists',
+    'angular-toArrayFilter',
     require('angular-loading-bar'),
     require('angular-sanitize'),
     require('angular-ui-bootstrap'),


### PR DESCRIPTION
In angular 1.5, using the orderBy filter on something that isn't an array throws an error.

Since the angular dependency in package.json is `"^1.4.8"`, a fresh install of this project will be broken.