### PR TITLE
Handle basepath in a service

### DIFF
--- a/src/services/BasePathSvc.js
+++ b/src/services/BasePathSvc.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = function(CredentialSvc) {
+  'ngInject';
+
+  var service = this;
+  var creds = CredentialSvc.get();
+  service.getBasePath = function () {
+    return [
+      'config',
+      creds.appId,
+      'flows'
+    ];
+  }
+
+  service.getSchemaBasePath = function () {
+   return [
+      'config',
+      creds.appId,
+      'schemas'
+    ];
+  }
+
+  return service;
+}

--- a/src/services/FieldSvc.js
+++ b/src/services/FieldSvc.js
@@ -1,16 +1,9 @@
 'use strict';
 
-module.exports = function(CredentialSvc, HttpSvc) {
+module.exports = function(HttpSvc, BasePathSvc) {
   'ngInject';
 
-  function basePath() {
-    var creds = CredentialSvc.get();
-    return [
-      'config',
-      creds.appId,
-      'flows'
-    ];
-  }
+  var basePath = BasePathSvc.getBasePath;
 
   this.getAll = function(flow) {
     return HttpSvc.get(basePath().concat([flow, 'fields']))

--- a/src/services/FlowSvc.js
+++ b/src/services/FlowSvc.js
@@ -1,16 +1,9 @@
 'use strict';
 
-module.exports = function(CredentialSvc, HttpSvc) {
+module.exports = function(BasePathSvc, HttpSvc) {
   'ngInject';
 
-  function basePath() {
-    var creds = CredentialSvc.get();
-    return [
-      'config',
-      creds.appId,
-      'flows'
-    ];
-  }
+  var basePath = BasePathSvc.getBasePath;
 
   this.getAll = function() {
     return HttpSvc.get(basePath())

--- a/src/services/SchemaSvc.js
+++ b/src/services/SchemaSvc.js
@@ -3,19 +3,11 @@
 var pluck = require('lodash/collection/pluck');
 var intersect = require('lodash/array/intersection');
 
-module.exports = function(CredentialSvc, HttpSvc, $q) {
+module.exports = function(BasePathSvc, HttpSvc, $q) {
   'ngInject';
 
   var self = this;
-
-  function basePath() {
-    var creds = CredentialSvc.get()
-    return [
-      'config',
-      creds.appId,
-      'schemas'
-    ];
-  }
+  var basePath = BasePathSvc.getSchemaBasePath;
 
   // Since lodash 3.10.1 doesn't have intersectionBy, we'll need to create our own
   // Remove this when we move to lodash 4.14.1+

--- a/src/services/fieldMetaSvc.js
+++ b/src/services/fieldMetaSvc.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(UtilSvc, HttpSvc) {
+module.exports = function(UtilSvc, HttpSvc, BasePathSvc) {
   'ngInject';
 
   function basePath() {

--- a/src/services/formsSvc.js
+++ b/src/services/formsSvc.js
@@ -1,16 +1,10 @@
 'use strict';
 
-module.exports = function(CredentialSvc, HttpSvc) {
+module.exports = function(BasePathSvc, HttpSvc) {
   'ngInject';
 
-  function basePath() {
-    var creds = CredentialSvc.get();
-    return [
-      'config',
-      creds.appId,
-      'flows'
-    ];
-  }
+  var basePath = BasePathSvc.getBasePath;
+
 
   this.getAll = function(flow) {
     return HttpSvc.get(basePath().concat([flow, 'forms']))

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,6 +2,7 @@
 
 require('angular').module('capi-ui')
 .constant('RegionMap', require('./RegionMapCnst'))
+.service('BasePathSvc', require('./BasePathSvc'))
 .service('CredentialSvc', require('./CredentialSvc'))
 .service('FileReaderSvc', require('./FileReaderSvc'))
 .service('FieldMetaSvc', require('./fieldMetaSvc'))

--- a/src/services/localesSvc.js
+++ b/src/services/localesSvc.js
@@ -1,16 +1,10 @@
 'use strict';
 
-module.exports = function(CredentialSvc, HttpSvc) {
+module.exports = function(BasePathSvc, HttpSvc) {
   'ngInject';
 
-  function basePath() {
-    var creds = CredentialSvc.get()
-    return [
-      'config',
-      creds.appId,
-      'flows'
-    ];
-  }
+  var basePath = BasePathSvc.getBasePath;
+
 
   this.getAll = function(flow) {
     return HttpSvc.get(basePath().concat([flow, 'locales']))

--- a/src/services/mailTemplatesSvc.js
+++ b/src/services/mailTemplatesSvc.js
@@ -1,16 +1,9 @@
 'use strict';
 
-module.exports = function(CredentialSvc, HttpSvc) {
+module.exports = function(BasePathSvc, HttpSvc) {
   'ngInject';
 
-  function basePath() {
-    var creds = CredentialSvc.get()
-    return [
-      'config',
-      creds.appId,
-      'flows'
-    ];
-  }
+  var basePath = BasePathSvc.getBasePath;
 
   this.getAll = function(flow) {
     // A non localized endpoint sure would be nice.

--- a/src/services/translationsSvc.js
+++ b/src/services/translationsSvc.js
@@ -1,17 +1,10 @@
 'use strict';
 var sortBy = require('lodash/collection/sortBy');
 
-module.exports = function(CredentialSvc, HttpSvc) {
+module.exports = function(BasePathSvc, HttpSvc) {
   'ngInject';
+  var basePath = BasePathSvc.getBasePath;
 
-  function basePath() {
-    var creds = CredentialSvc.get()
-    return [
-      'config',
-      creds.appId,
-      'flows'
-    ];
-  }
 
   this.getAll = function(flow) {
     return HttpSvc


### PR DESCRIPTION
### Overview:
- Basepath is generated via a function in many services and it's difficult to change it. For example, I had to work on removing the `beta` from the old version of the app. Having it generated by a single service would have made it so much easier